### PR TITLE
feat: boost easy review intervals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Welcome to GeoMeta! This repository houses a Next.js application in `app/` along
 - **Feedback handling:**
   - `Hard` (quality 1): new cards reappear within the session; previously learned cards become *lapsed* and are rescheduled for 7 days later.
   - `Good` (quality 3): increases the interval (e.g., 1 → 6 → 15 days).
-  - `Easy` (quality 5): expands the interval beyond `Good` for well-known cards.
+  - `Easy` (quality 5): from the second review onward applies a 1.3× bonus (e.g., 1 → 6 → 20 days).
 - **Review stats:** the API exposes counts of due new and review cards so the UI can display daily progress.
 
 Happy hacking!

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ NEW v2.0: Userscript → Backend API → LearnableMeta API → JSON Storage → 
 - **Technical metadata** for debugging and reference
 - **Export capabilities** built into the data structure
 
+### 🧠 Spaced Repetition Memorizer
+- Built-in study mode using a simplified SM-2 algorithm
+- "Good" answers progress intervals like 1 → 6 → 15 days
+- "Easy" answers add a 30% bonus after the second review for 1 → 6 → 20 days
+
 ## 🚀 Quick Start
 
 ### 1. Prerequisites

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -62,6 +62,9 @@ function calculateNextReview(
   } else {
     newRepetitions = repetitions + 1;
     newInterval = Math.round(interval * easeFactor);
+    if (quality === 5) {
+      newInterval = Math.round(newInterval * 1.3);
+    }
     newState = "review";
   }
 


### PR DESCRIPTION
## Summary
- lengthen "Easy" spaced-repetition intervals with a 1.3× multiplier after the second review
- document SM‑2 intervals for Good and Easy responses

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e65fe8184833282d006ad7dae70ea