### PR TITLE
fix: validate memorizer request parameters

### DIFF
--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -193,7 +193,12 @@ export async function POST(request: Request) {
   try {
     const { locationId, quality } = await request.json();
 
-    if (!locationId || quality === undefined || quality < 0 || quality > 5) {
+    if (
+      typeof locationId !== "number" ||
+      !Number.isInteger(quality) ||
+      quality < 0 ||
+      quality > 5
+    ) {
       return NextResponse.json(
         { success: false, message: "Invalid input" },
         { status: 400 },


### PR DESCRIPTION
## Summary
- validate `locationId` is a number and `quality` is an integer before updating memorizer progress

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e67aa7bac8332a7c6c066fd209558