### PR TITLE
refactor: convert MemorizerCard to TypeScript

### DIFF
--- a/app/src/app/memorizer/page.tsx
+++ b/app/src/app/memorizer/page.tsx
@@ -5,23 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { BrainCircuit, Loader2, AlertTriangle, ChevronLeft } from "lucide-react";
 import Link from "next/link";
-import MemorizerCard from "@/components/MemorizerCard"; // Use the new component
-
-// This is the full Location type that MemorizerCard expects
-interface Location {
-  id: number;
-  pano_id: string;
-  map_id: string;
-  country: string;
-  country_code: string | null;
-  meta_name: string | null;
-  note: string | null;
-  footer: string | null;
-  images: string[];
-  raw_data: Record<string, any>;
-  created_at: string;
-  updated_at: string;
-}
+import MemorizerCard, { Location } from "@/components/MemorizerCard.tsx"; // Use the new component
 
 export default function MemorizerPage() {
   const [location, setLocation] = useState<Location | null>(null);

--- a/app/src/components/MemorizerCard.tsx
+++ b/app/src/components/MemorizerCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, type MouseEvent } from "react";
 import Image from "next/image";
 import DOMPurify from "dompurify";
 import { Button } from "@/components/ui/button";
@@ -11,26 +11,45 @@ import {
   MapPin,
 } from "lucide-react";
 
+export interface Location {
+  id: number;
+  pano_id: string;
+  map_id: string;
+  country: string;
+  country_code: string | null;
+  meta_name: string | null;
+  note: string | null;
+  footer: string | null;
+  images: string[];
+  raw_data: Record<string, any>;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MemorizerCardProps {
+  location: Location;
+}
+
 // This is a dedicated version of MetaCard for the memorizer page.
 // It's not a modal, but a large, standalone card.
-export default function MemorizerCard({ location }) {
+export default function MemorizerCard({ location }: MemorizerCardProps) {
   // --- STATE MANAGEMENT ---
-  const [currentImageIndex, setCurrentImageIndex] = useState(0);
-  const [imageError, setImageError] = useState({});
+  const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
+  const [imageError, setImageError] = useState<Record<string, boolean>>({});
   const [showTechDetails, setShowTechDetails] = useState(false);
-  const techDetailsRef = useRef(null);
+  const techDetailsRef = useRef<HTMLDivElement | null>(null);
 
   // --- HANDLER FUNCTIONS ---
-  const handleImageError = (imageUrl) => {
+  const handleImageError = (imageUrl: string) => {
     setImageError((prev) => ({ ...prev, [imageUrl]: true }));
   };
 
-  const nextImage = (e) => {
+  const nextImage = (e: MouseEvent) => {
     e.stopPropagation();
     setCurrentImageIndex((prev) => (prev + 1) % images.length);
   };
 
-  const previousImage = (e) => {
+  const previousImage = (e: MouseEvent) => {
     e.stopPropagation();
     setCurrentImageIndex((prev) => (prev - 1 + images.length) % images.length);
   };
@@ -40,9 +59,9 @@ export default function MemorizerCard({ location }) {
     ? location.images.filter((img) => img && !imageError[img])
     : [];
 
-  const proxyUrl = (u) => (u ? `/api/img?u=${encodeURIComponent(u)}` : "");
+  const proxyUrl = (u: string) => (u ? `/api/img?u=${encodeURIComponent(u)}` : "");
 
-  const extractLink = (html) => {
+  const extractLink = (html: string | null) => {
     if (!html) return null;
     const doc = new DOMParser().parseFromString(html, "text/html");
     const link = doc.querySelector("a");
@@ -84,20 +103,24 @@ export default function MemorizerCard({ location }) {
                       className="flex-shrink-0"
                     >
                       <Image
-                        src={proxyUrl(`https://flagcdn.com/64x48/${location.country_code.toLowerCase()}.png`)} width={32} height={24}
+                        src={proxyUrl(`https://flagcdn.com/64x48/${location.country_code.toLowerCase()}.png`)}
+                        width={32}
+                        height={24}
                         alt={`${location.country} flag`}
                         className="rounded-sm border-slate-600 hover:border-blue-400 transition-colors"
                         unoptimized
-                        onError={(e) => (e.target.style.display = "none")}
+                        onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
                       />
                     </a>
                   ) : (
                     <Image
-                      src={proxyUrl(`https://flagcdn.com/64x48/${location.country_code.toLowerCase()}.png`)} width={32} height={24}
+                      src={proxyUrl(`https://flagcdn.com/64x48/${location.country_code.toLowerCase()}.png`)}
+                      width={32}
+                      height={24}
                       alt={`${location.country} flag`}
                       className="rounded-sm border-slate-600 flex-shrink-0"
                       unoptimized
-                      onError={(e) => (e.target.style.display = "none")}
+                      onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
                     />
                   )}
                 </>
@@ -131,7 +154,7 @@ export default function MemorizerCard({ location }) {
                 height={1080}
                 className="w-full max-h-[60vh] object-contain rounded-md"
                 unoptimized
-                onError={(e) => handleImageError(images[currentImageIndex])}
+                onError={() => handleImageError(images[currentImageIndex])}
               />
 
               {images.length > 1 && (

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "allowImportingTsExtensions": true,
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- convert MemorizerCard to TypeScript with a dedicated `Location` interface and typed props
- update memorizer page to import the new `.tsx` component and shared `Location` type
- allow TypeScript extension imports via `allowImportingTsExtensions`

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e679349408332b9afe233d89bde36