### PR TITLE
fix: sort due cards by state and index

### DIFF
--- a/app/db/migrate-memorizer-state.mjs
+++ b/app/db/migrate-memorizer-state.mjs
@@ -24,6 +24,9 @@ function migrate() {
 
     // Index the state column for faster lookups
     db.exec(`CREATE INDEX IF NOT EXISTS idx_memorizer_state ON memorizer_progress (state);`);
+    db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_memorizer_state_due_date ON memorizer_progress (state, due_date);`,
+    );
 
     console.log('✅ Added "state" and "lapses" columns to memorizer_progress table.');
 

--- a/app/db/migrate-memorizer.mjs
+++ b/app/db/migrate-memorizer.mjs
@@ -28,6 +28,9 @@ function migrate() {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_memorizer_due_date ON memorizer_progress (due_date);`);
   db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_memorizer_location_id ON memorizer_progress (location_id);`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_memorizer_state ON memorizer_progress (state);`);
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_memorizer_state_due_date ON memorizer_progress (state, due_date);`,
+  );
 
   // Trigger to automatically update the 'updated_at' timestamp
   db.exec(`

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -95,13 +95,14 @@ export async function GET() {
       LEFT JOIN memorizer_progress mp ON l.id = mp.location_id
       WHERE mp.due_date <= CURRENT_TIMESTAMP OR mp.id IS NULL
       ORDER BY
+        CASE WHEN mp.due_date IS NULL THEN 1 ELSE 0 END,
+        mp.due_date ASC,
         CASE
           WHEN mp.state = 'lapsed' THEN 0
           WHEN mp.state = 'review' THEN 1
           WHEN mp.id IS NULL OR mp.state IN ('new', 'learning') THEN 2
           ELSE 3
         END,
-        mp.due_date ASC,
         RANDOM()
       LIMIT 1
     `,


### PR DESCRIPTION
## Summary
- refine memorizer query to prioritize overdue cards and prefer lapsed over new when due
- add composite state/due date indexes for faster memorizer lookups

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test` *(fails: The module '/workspace/geometa/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node' was compiled against a different Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_688e6996db3c8332b7842342aead20e1