### PR TITLE
fix: normalize memorizer due dates

### DIFF
--- a/app/src/__tests__/memorizerApi.test.ts
+++ b/app/src/__tests__/memorizerApi.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { db } from '../lib/db';
+import { GET, POST } from '../app/api/memorizer/route';
+
+describe('memorizer API', () => {
+  beforeEach(() => {
+    db.exec(`
+      DROP TABLE IF EXISTS locations;
+      CREATE TABLE locations (id INTEGER PRIMARY KEY AUTOINCREMENT);
+      DROP TABLE IF EXISTS memorizer_progress;
+      CREATE TABLE memorizer_progress (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        location_id INTEGER NOT NULL UNIQUE,
+        repetitions INTEGER NOT NULL DEFAULT 0,
+        ease_factor REAL NOT NULL DEFAULT 2.5,
+        "interval" INTEGER NOT NULL DEFAULT 0,
+        due_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        state TEXT NOT NULL DEFAULT 'new',
+        lapses INTEGER NOT NULL DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    db.prepare('INSERT INTO locations (id) VALUES (1)').run();
+  });
+
+  it('returns scheduled cards as due after time advances', async () => {
+    await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ locationId: 1, quality: 5 }),
+      }),
+    );
+
+    const { due_date } = db
+      .prepare('SELECT due_date FROM memorizer_progress WHERE location_id = ?')
+      .get(1) as { due_date: string };
+    const pastIso = new Date(Date.parse(due_date) - 2 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare('UPDATE memorizer_progress SET due_date = ? WHERE location_id = ?').run(pastIso, 1);
+
+    const res = await GET();
+    const data = await res.json();
+
+    expect(data.locationId).toBe(1);
+    expect(data.stats).toEqual({ new: 1, review: 0, lapsed: 0 });
+  });
+});
+

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -93,10 +93,10 @@ export async function GET() {
       SELECT l.id
       FROM locations l
       LEFT JOIN memorizer_progress mp ON l.id = mp.location_id
-      WHERE mp.due_date <= CURRENT_TIMESTAMP OR mp.id IS NULL
+      WHERE datetime(mp.due_date) <= CURRENT_TIMESTAMP OR mp.id IS NULL
       ORDER BY
         CASE WHEN mp.due_date IS NULL THEN 1 ELSE 0 END,
-        mp.due_date ASC,
+        datetime(mp.due_date) ASC,
         CASE
           WHEN mp.state = 'lapsed' THEN 0
           WHEN mp.state = 'review' THEN 1
@@ -146,21 +146,21 @@ export async function GET() {
         SELECT
           SUM(
             CASE
-              WHEN mp.id IS NULL OR (mp.state IN ('new', 'learning') AND mp.due_date <= CURRENT_TIMESTAMP)
+              WHEN mp.id IS NULL OR (mp.state IN ('new', 'learning') AND datetime(mp.due_date) <= CURRENT_TIMESTAMP)
                 THEN 1
               ELSE 0
             END
           ) AS new_due,
           SUM(
             CASE
-              WHEN mp.state = 'review' AND mp.due_date <= CURRENT_TIMESTAMP
+              WHEN mp.state = 'review' AND datetime(mp.due_date) <= CURRENT_TIMESTAMP
                 THEN 1
               ELSE 0
             END
           ) AS review_due,
           SUM(
             CASE
-              WHEN mp.state = 'lapsed' AND mp.due_date <= CURRENT_TIMESTAMP
+              WHEN mp.state = 'lapsed' AND datetime(mp.due_date) <= CURRENT_TIMESTAMP
                 THEN 1
               ELSE 0
             END
@@ -252,7 +252,7 @@ export async function POST(request: Request) {
         "interval" = ?,
         state = ?,
         lapses = ?,
-        due_date = ?
+        due_date = datetime(?)
       WHERE location_id = ?
     `,
     ).run(


### PR DESCRIPTION
## Summary
- ensure SQLite parses ISO due dates by wrapping them with `datetime()` in selection and stats queries
- normalize stored `due_date` values using `datetime(?)` when updating progress
- add regression test verifying a scheduled card becomes due and is counted in stats

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688e6e12d51883328f1634be629e8280