### PR TITLE
fix: mark new hard answers as lapsed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Welcome to GeoMeta! This repository houses a Next.js application in `app/` along
 - The spaced-repetition system uses a simplified SM-2 approach.
 - **Card selection:** prioritizes due cards (new or scheduled for today/past) and chooses the most overdue; if none are due, shows the least-reviewed cards.
 - **Feedback handling:**
-  - `Hard` (quality 1): new cards reappear within the session; previously learned cards become *lapsed* and are rescheduled for 7 days later.
+  - `Hard` (quality 1): marks the card as *lapsed*—new cards reappear within the session, while previously learned cards are rescheduled for 7 days later.
   - `Good` (quality 3): increases the interval (e.g., 1 → 6 → 15 days).
   - `Easy` (quality 5): from the second review onward applies a 1.3× bonus (e.g., 1 → 6 → 20 days).
 - **Review stats:** the API exposes counts of due new and review cards so the UI can display daily progress.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ NEW v2.0: Userscript → Backend API → LearnableMeta API → JSON Storage → 
 
 ### 🧠 Spaced Repetition Memorizer
 - Built-in study mode using a simplified SM-2 algorithm
+- "Hard" answers mark the card as lapsed, show it again within minutes, and count toward lapsed stats
 - "Good" answers progress intervals like 1 → 6 → 15 days
 - "Easy" answers add a 30% bonus after the second review for 1 → 6 → 20 days
 

--- a/app/src/__tests__/calculateNextReview.test.ts
+++ b/app/src/__tests__/calculateNextReview.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { calculateNextReview } from '../app/api/memorizer/route';
 
 describe('calculateNextReview', () => {
-  it('returns reviewDelayMinutes for new card marked Hard', () => {
+  it('marks new Hard answers as lapsed and returns reviewDelayMinutes', () => {
     const result = calculateNextReview(1, 0, 2.5, 0, 'new', 0);
     expect(result.reviewDelayMinutes).toBe(5);
+    expect(result.state).toBe('lapsed');
+    expect(result.lapses).toBe(1);
   });
 
   it('resets interval and repetitions for lapsed cards', () => {

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -21,15 +21,15 @@ export function calculateNextReview(
   let newState = state;
   let newLapses = lapses;
 
-  // Learning phase for brand new cards: if a new card is marked hard,
-  // show it again shortly instead of waiting a full day
+  // Brand new card answered hard: count it as a lapse and
+  // reshow it shortly instead of waiting a full day
   if (repetitions === 0 && quality < 3 && state !== "lapsed") {
     newLapses += 1;
     return {
       repetitions: 0,
       easeFactor,
       interval: 0,
-      state: "learning",
+      state: "lapsed",
       lapses: newLapses,
       reviewDelayMinutes: 5,
     } as const;


### PR DESCRIPTION
## Summary
- mark new Hard answers as lapsed and reshow quickly
- test and document lapsed handling in memorizer

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`

------
https://chatgpt.com/codex/tasks/task_e_688e72135890833288578d48dd272454