### PR TITLE
feat: add total memorizer stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ NEW v2.0: Userscript → Backend API → LearnableMeta API → JSON Storage → 
 - Built-in study mode using a simplified SM-2 algorithm
 - "Good" answers progress intervals like 1 → 6 → 15 days
 - "Easy" answers add a 30% bonus after the second review for 1 → 6 → 20 days
+- Header shows due-today and total counts for new, review, and lapsed cards
 
 ## 🚀 Quick Start
 

--- a/app/src/__tests__/memorizerApi.test.ts
+++ b/app/src/__tests__/memorizerApi.test.ts
@@ -42,7 +42,14 @@ describe('memorizer API', () => {
     const data = await res.json();
 
     expect(data.locationId).toBe(1);
-    expect(data.stats).toEqual({ new: 1, review: 0, lapsed: 0 });
+    expect(data.stats).toEqual({
+      new: 1,
+      review: 0,
+      lapsed: 0,
+      newTotal: 1,
+      reviewTotal: 0,
+      lapsedTotal: 0,
+    });
   });
 });
 

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -164,12 +164,37 @@ export async function GET() {
                 THEN 1
               ELSE 0
             END
-          ) AS lapsed_due
+          ) AS lapsed_due,
+          SUM(
+            CASE
+              WHEN mp.id IS NULL OR mp.state IN ('new', 'learning') THEN 1
+              ELSE 0
+            END
+          ) AS new_total,
+          SUM(
+            CASE
+              WHEN mp.state = 'review' THEN 1
+              ELSE 0
+            END
+          ) AS review_total,
+          SUM(
+            CASE
+              WHEN mp.state = 'lapsed' THEN 1
+              ELSE 0
+            END
+          ) AS lapsed_total
         FROM locations l
         LEFT JOIN memorizer_progress mp ON l.id = mp.location_id
       `,
       )
-      .get() as { new_due: number; review_due: number; lapsed_due: number };
+      .get() as {
+        new_due: number;
+        review_due: number;
+        lapsed_due: number;
+        new_total: number;
+        review_total: number;
+        lapsed_total: number;
+      };
 
     return NextResponse.json({
       success: true,
@@ -178,6 +203,9 @@ export async function GET() {
         new: counts.new_due ?? 0,
         review: counts.review_due ?? 0,
         lapsed: counts.lapsed_due ?? 0,
+        newTotal: counts.new_total ?? 0,
+        reviewTotal: counts.review_total ?? 0,
+        lapsedTotal: counts.lapsed_total ?? 0,
       },
     });
   } catch (error) {

--- a/app/src/app/memorizer/page.tsx
+++ b/app/src/app/memorizer/page.tsx
@@ -11,7 +11,20 @@ export default function MemorizerPage() {
   const [location, setLocation] = useState<Location | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [stats, setStats] = useState<{ new: number; review: number; lapsed: number } | null>(null);
+  const [
+    stats,
+    setStats,
+  ] = useState<
+    | {
+        new: number;
+        review: number;
+        lapsed: number;
+        newTotal: number;
+        reviewTotal: number;
+        lapsedTotal: number;
+      }
+    | null
+  >(null);
 
   const fetchNextCard = useCallback(async () => {
     setLoading(true);
@@ -145,9 +158,9 @@ export default function MemorizerPage() {
             <div className="w-10 sm:w-36 text-right">
               {stats && !loading && (
                 <span className="text-xs sm:text-sm text-slate-500">
-              {stats.new} new, {stats.review} reviews, {stats.lapsed} lapsed
-            </span>
-          )}
+                  {stats.new}/{stats.newTotal} new, {stats.review}/{stats.reviewTotal} reviews, {stats.lapsed}/{stats.lapsedTotal} lapsed due today
+                </span>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- compute both due and total counts for new, review, and lapsed cards
- display due/total stats on memorizer page header
- document memorizer stats and update tests

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688e72375e8c83329ce34199e8cdf13d