### PR TITLE
fix: treat first-time failures as learning

### DIFF
--- a/app/src/__tests__/calculateNextReview.test.ts
+++ b/app/src/__tests__/calculateNextReview.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { calculateNextReview } from '../app/api/memorizer/route';
 
 describe('calculateNextReview', () => {
-  it('marks new Hard answers as lapsed and returns reviewDelayMinutes', () => {
+  it('keeps new Hard answers in learning with a short delay', () => {
     const result = calculateNextReview(1, 0, 2.5, 0, 'new', 0);
     expect(result.reviewDelayMinutes).toBe(5);
-    expect(result.state).toBe('lapsed');
-    expect(result.lapses).toBe(1);
+    expect(result.state).toBe('learning');
+    expect(result.lapses).toBe(0);
   });
 
   it('resets interval and repetitions for lapsed cards', () => {

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -21,15 +21,14 @@ export function calculateNextReview(
   let newState = state;
   let newLapses = lapses;
 
-  // Brand new card answered hard: count it as a lapse and
-  // reshow it shortly instead of waiting a full day
+  // Brand new card answered hard: keep it in learning and reshow
+  // it shortly instead of waiting a full day or counting a lapse
   if (repetitions === 0 && quality < 3 && state !== "lapsed") {
-    newLapses += 1;
     return {
       repetitions: 0,
       easeFactor,
       interval: 0,
-      state: "lapsed",
+      state: "learning",
       lapses: newLapses,
       reviewDelayMinutes: 5,
     } as const;


### PR DESCRIPTION
## Summary
- avoid counting lapses on initial failure and keep card in learning with short delay
- update spaced repetition tests for learning state instead of lapsed

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688f02e2b21883328a481a68e38b52ca