### PR TITLE
feat: include location in memorizer API

### DIFF
--- a/app/src/__tests__/memorizerApi.test.ts
+++ b/app/src/__tests__/memorizerApi.test.ts
@@ -6,7 +6,12 @@ describe('memorizer API', () => {
   beforeEach(() => {
     db.exec(`
       DROP TABLE IF EXISTS locations;
-      CREATE TABLE locations (id INTEGER PRIMARY KEY AUTOINCREMENT);
+      CREATE TABLE locations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        country TEXT,
+        images TEXT,
+        raw_data TEXT
+      );
       DROP TABLE IF EXISTS memorizer_progress;
       CREATE TABLE memorizer_progress (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -21,7 +26,9 @@ describe('memorizer API', () => {
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
       );
     `);
-    db.prepare('INSERT INTO locations (id) VALUES (1)').run();
+    db.prepare(
+      "INSERT INTO locations (id, country, images, raw_data) VALUES (?, ?, ?, ?)",
+    ).run(1, "Testland", "[]", "{}");
   });
 
   it('returns scheduled cards as due after time advances', async () => {
@@ -41,7 +48,14 @@ describe('memorizer API', () => {
     const res = await GET();
     const data = await res.json();
 
-    expect(data.locationId).toBe(1);
+    expect(data.location).toEqual(
+      expect.objectContaining({
+        id: 1,
+        country: 'Testland',
+        images: [],
+        raw_data: {},
+      }),
+    );
     expect(data.stats).toEqual({
       new: 1,
       review: 0,

--- a/app/src/app/memorizer/page.tsx
+++ b/app/src/app/memorizer/page.tsx
@@ -37,17 +37,9 @@ export default function MemorizerPage() {
       if (!memorizerRes.ok || !memorizerData.success) {
         throw new Error(memorizerData.message || "Could not get next card.");
       }
-      const { locationId, stats: newStats } = memorizerData;
+      const { location: newLocation, stats: newStats } = memorizerData;
       setStats(newStats);
-
-      const metaRes = await fetch(`/api/meta/${locationId}`);
-      const metaData = await metaRes.json();
-
-      if (!metaRes.ok || !metaData.success) {
-        throw new Error(metaData.message || "Could not load location data.");
-      }
-
-      setLocation(metaData.location);
+      setLocation(newLocation);
     } catch (err) {
       setError(err instanceof Error ? err.message : "An unknown error occurred");
     } finally {


### PR DESCRIPTION
## Summary
- return full location object from memorizer API and parse JSON fields
- consume location directly in Memorizer page
- test memorizer API response structure

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688f033490508332bdfc119e7bddcfc2