### PR TITLE
feat: store due date as unix timestamp

### DIFF
--- a/app/db/migrate-memorizer-due-date-int.mjs
+++ b/app/db/migrate-memorizer-due-date-int.mjs
@@ -1,0 +1,79 @@
+import Database from 'better-sqlite3';
+
+const db = new Database('db/geometa.db', { verbose: console.log });
+
+function migrate() {
+  console.log('🚀 Migrating memorizer_progress.due_date to integer timestamps...');
+
+  const tableInfo = db.prepare('PRAGMA table_info(memorizer_progress)').all();
+  const dueDateCol = tableInfo.find(col => col.name === 'due_date');
+
+  if (!dueDateCol) {
+    console.log('ℹ️ Table memorizer_progress does not exist. Skipping.');
+    return;
+  }
+
+  if (dueDateCol.type.toUpperCase() === 'INTEGER') {
+    console.log('ℹ️ due_date is already INTEGER. Skipping migration.');
+    return;
+  }
+
+  db.exec('BEGIN TRANSACTION;');
+
+  db.exec(`
+    CREATE TABLE memorizer_progress_new (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      location_id INTEGER NOT NULL UNIQUE,
+      repetitions INTEGER NOT NULL DEFAULT 0,
+      ease_factor REAL NOT NULL DEFAULT 2.5,
+      "interval" INTEGER NOT NULL DEFAULT 0,
+      due_date INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+      state TEXT NOT NULL DEFAULT 'new',
+      lapses INTEGER NOT NULL DEFAULT 0,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (location_id) REFERENCES locations (id) ON DELETE CASCADE
+    );
+  `);
+
+  db.exec(`
+    INSERT INTO memorizer_progress_new (
+      id, location_id, repetitions, ease_factor, "interval", due_date, state, lapses, created_at, updated_at
+    )
+    SELECT
+      id,
+      location_id,
+      repetitions,
+      ease_factor,
+      "interval",
+      CAST(strftime('%s', due_date) AS INTEGER) AS due_date,
+      state,
+      lapses,
+      created_at,
+      updated_at
+    FROM memorizer_progress;
+  `);
+
+  db.exec('DROP TABLE memorizer_progress;');
+  db.exec('ALTER TABLE memorizer_progress_new RENAME TO memorizer_progress;');
+
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_memorizer_due_date ON memorizer_progress (due_date);`);
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_memorizer_location_id ON memorizer_progress (location_id);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_memorizer_state ON memorizer_progress (state);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_memorizer_state_due_date ON memorizer_progress (state, due_date);`);
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS memorizer_progress_updated_at
+    AFTER UPDATE ON memorizer_progress FOR EACH ROW
+    BEGIN
+      UPDATE memorizer_progress SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+    END;
+  `);
+
+  db.exec('COMMIT;');
+
+  console.log('✅ Completed due_date migration to integer timestamps.');
+}
+
+migrate();
+

--- a/app/db/migrate-memorizer.mjs
+++ b/app/db/migrate-memorizer.mjs
@@ -14,7 +14,7 @@ function migrate() {
       repetitions INTEGER NOT NULL DEFAULT 0,
       ease_factor REAL NOT NULL DEFAULT 2.5, -- A factor controlling interval growth
       "interval" INTEGER NOT NULL DEFAULT 0, -- Days until next review
-      due_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      due_date INTEGER NOT NULL DEFAULT (strftime('%s','now')),
       state TEXT NOT NULL DEFAULT 'new',
       lapses INTEGER NOT NULL DEFAULT 0,
       -- Timestamps

--- a/app/src/__tests__/memorizerApi.test.ts
+++ b/app/src/__tests__/memorizerApi.test.ts
@@ -19,7 +19,7 @@ describe('memorizer API', () => {
         repetitions INTEGER NOT NULL DEFAULT 0,
         ease_factor REAL NOT NULL DEFAULT 2.5,
         "interval" INTEGER NOT NULL DEFAULT 0,
-        due_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        due_date INTEGER NOT NULL DEFAULT (strftime('%s','now')),
         state TEXT NOT NULL DEFAULT 'new',
         lapses INTEGER NOT NULL DEFAULT 0,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -41,9 +41,9 @@ describe('memorizer API', () => {
 
     const { due_date } = db
       .prepare('SELECT due_date FROM memorizer_progress WHERE location_id = ?')
-      .get(1) as { due_date: string };
-    const pastIso = new Date(Date.parse(due_date) - 2 * 24 * 60 * 60 * 1000).toISOString();
-    db.prepare('UPDATE memorizer_progress SET due_date = ? WHERE location_id = ?').run(pastIso, 1);
+      .get(1) as { due_date: number };
+    const pastTs = due_date - 2 * 24 * 60 * 60;
+    db.prepare('UPDATE memorizer_progress SET due_date = ? WHERE location_id = ?').run(pastTs, 1);
 
     const res = await GET();
     const data = await res.json();

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -112,10 +112,10 @@ export async function GET() {
       SELECT l.*
       FROM locations l
       LEFT JOIN memorizer_progress mp ON l.id = mp.location_id
-      WHERE datetime(mp.due_date) <= CURRENT_TIMESTAMP OR mp.id IS NULL
+      WHERE mp.due_date <= strftime('%s','now') OR mp.id IS NULL
       ORDER BY
         CASE WHEN mp.due_date IS NULL THEN 1 ELSE 0 END,
-        datetime(mp.due_date) ASC,
+        mp.due_date ASC,
         CASE
           WHEN mp.state = 'lapsed' THEN 0
           WHEN mp.state = 'review' THEN 1
@@ -165,21 +165,21 @@ export async function GET() {
         SELECT
           SUM(
             CASE
-              WHEN mp.id IS NULL OR (mp.state IN ('new', 'learning') AND datetime(mp.due_date) <= CURRENT_TIMESTAMP)
+              WHEN mp.id IS NULL OR (mp.state IN ('new', 'learning') AND mp.due_date <= strftime('%s','now'))
                 THEN 1
               ELSE 0
             END
           ) AS new_due,
           SUM(
             CASE
-              WHEN mp.state = 'review' AND datetime(mp.due_date) <= CURRENT_TIMESTAMP
+              WHEN mp.state = 'review' AND mp.due_date <= strftime('%s','now')
                 THEN 1
               ELSE 0
             END
           ) AS review_due,
           SUM(
             CASE
-              WHEN mp.state = 'lapsed' AND datetime(mp.due_date) <= CURRENT_TIMESTAMP
+              WHEN mp.state = 'lapsed' AND mp.due_date <= strftime('%s','now')
                 THEN 1
               ELSE 0
             END
@@ -295,6 +295,7 @@ export async function POST(request: Request) {
     } else {
       dueDate.setDate(dueDate.getDate() + interval);
     }
+    const dueTimestamp = Math.floor(dueDate.getTime() / 1000);
 
     db.prepare(
       `
@@ -305,7 +306,7 @@ export async function POST(request: Request) {
         "interval" = ?,
         state = ?,
         lapses = ?,
-        due_date = datetime(?)
+        due_date = ?
       WHERE location_id = ?
     `,
     ).run(
@@ -314,7 +315,7 @@ export async function POST(request: Request) {
       interval,
       state,
       lapses,
-      dueDate.toISOString(),
+      dueTimestamp,
       locationId,
     );
 


### PR DESCRIPTION
## Summary
- persist memorizer `due_date` as integer seconds since epoch and index accordingly
- migrate existing `due_date` values to integers with a new migration script
- compare timestamps numerically in memorizer API and store updated review times as integers

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688f0660a78c8332934d239b9b9efa14