### PR TITLE
fix: avoid ORDER BY RANDOM in memorizer selection

### DIFF
--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -122,7 +122,7 @@ export async function GET() {
           WHEN mp.id IS NULL OR mp.state IN ('new', 'learning') THEN 2
           ELSE 3
         END,
-        RANDOM()
+        l.id ASC
       LIMIT 1
     `,
       )
@@ -130,7 +130,7 @@ export async function GET() {
 
     // If no cards are due, just pick a random one that has been seen least
     if (!nextCard) {
-      nextCard = db
+      const candidates = db
         .prepare(
           `
         SELECT l.*
@@ -144,11 +144,15 @@ export async function GET() {
             ELSE 3
           END,
           mp.repetitions ASC,
-          RANDOM()
-        LIMIT 1
+          l.id ASC
+        LIMIT 10
       `,
         )
-        .get() as LocationRow | undefined;
+        .all() as LocationRow[];
+
+      if (candidates.length > 0) {
+        nextCard = candidates[Math.floor(Math.random() * candidates.length)];
+      }
     }
 
     if (!nextCard) {


### PR DESCRIPTION
## Summary
- replace SQL tie-breaker RANDOM() with deterministic location ordering
- select top 10 least-reviewed cards and randomize choice in memory

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688f065a37908332a33afb5979cb516d