### PR TITLE
feat: add again and hard review options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ Welcome to GeoMeta! This repository houses a Next.js application in `app/` along
 - The spaced-repetition system uses a simplified SM-2 approach.
 - **Card selection:** prioritizes due cards (new or scheduled for today/past) and chooses the most overdue; if none are due, shows the least-reviewed cards.
 - **Feedback handling:**
-  - `Hard` (quality 1): marks the card as *lapsed*—new cards reappear within the session, while previously learned cards are rescheduled for 7 days later.
+  - `Again` (quality 0): marks the card as *lapsed* and schedules it about a week later.
+  - `Hard` (quality 2): halves the current interval without counting as a lapse.
   - `Good` (quality 3): increases the interval (e.g., 1 → 6 → 15 days).
   - `Easy` (quality 5): from the second review onward applies a 1.3× bonus (e.g., 1 → 6 → 20 days).
 - **Review stats:** the API exposes counts of due new and review cards so the UI can display daily progress.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ NEW v2.0: Userscript → Backend API → LearnableMeta API → JSON Storage → 
 
 ### 🧠 Spaced Repetition Memorizer
 - Built-in study mode using a simplified SM-2 algorithm
-- "Hard" answers mark the card as lapsed, show it again within minutes, and count toward lapsed stats
+- "Again" answers mark the card as lapsed and count toward lapsed stats
+- "Hard" answers halve the current interval without lapsing
 - "Good" answers progress intervals like 1 → 6 → 15 days
 - "Easy" answers add a 30% bonus after the second review for 1 → 6 → 20 days
 - Header shows due-today and total counts for new, review, and lapsed cards

--- a/app/src/__tests__/calculateNextReview.test.ts
+++ b/app/src/__tests__/calculateNextReview.test.ts
@@ -3,19 +3,24 @@ import { calculateNextReview } from '../app/api/memorizer/route';
 
 describe('calculateNextReview', () => {
   it('keeps new Hard answers in learning with a short delay', () => {
-    const result = calculateNextReview(1, 0, 2.5, 0, 'new', 0);
+    const result = calculateNextReview(2, 0, 2.5, 0, 'new', 0);
     expect(result.reviewDelayMinutes).toBe(5);
     expect(result.state).toBe('learning');
     expect(result.lapses).toBe(0);
   });
 
-  it('resets interval and repetitions for lapsed cards', () => {
-    const result = calculateNextReview(1, 3, 2.5, 15, 'review', 0);
+  it('treats Again answers as lapses', () => {
+    const result = calculateNextReview(0, 3, 2.5, 15, 'review', 0);
     expect(result.interval).toBe(7);
     expect(result.repetitions).toBe(0);
+    expect(result.state).toBe('lapsed');
   });
 
-  it('increases interval and ease factor for Good and Easy grades', () => {
+  it('adjusts intervals for Hard, Good, and Easy grades', () => {
+    const hard = calculateNextReview(2, 2, 2.5, 6, 'review', 0);
+    expect(hard.interval).toBe(3);
+    expect(hard.easeFactor).toBeCloseTo(2.18, 2);
+
     const good = calculateNextReview(3, 2, 2.5, 6, 'review', 0);
     expect(good.interval).toBe(15);
     expect(good.easeFactor).toBeCloseTo(2.36, 2);

--- a/app/src/__tests__/memorizerApi.test.ts
+++ b/app/src/__tests__/memorizerApi.test.ts
@@ -65,5 +65,31 @@ describe('memorizer API', () => {
       lapsedTotal: 0,
     });
   });
+
+  it('validates allowed quality values', async () => {
+    const acceptAgain = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ locationId: 1, quality: 0 }),
+      }),
+    );
+    expect(acceptAgain.status).toBe(200);
+
+    const acceptHard = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ locationId: 1, quality: 2 }),
+      }),
+    );
+    expect(acceptHard.status).toBe(200);
+
+    const reject = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ locationId: 1, quality: 4 }),
+      }),
+    );
+    expect(reject.status).toBe(400);
+  });
 });
 

--- a/app/src/app/memorizer/page.tsx
+++ b/app/src/app/memorizer/page.tsx
@@ -115,13 +115,31 @@ export default function MemorizerPage() {
 
           {/* Review Buttons */}
           <div className="mt-8 flex-shrink-0 w-full max-w-lg flex flex-col sm:flex-row justify-around items-center gap-4">
-            <Button onClick={() => handleUpdateProgress(1)} variant="destructive" className="w-full sm:w-32 h-12 text-lg font-semibold">
+            <Button
+              onClick={() => handleUpdateProgress(0)}
+              variant="destructive"
+              className="w-full sm:w-32 h-12 text-lg font-semibold"
+            >
+              Again
+            </Button>
+            <Button
+              onClick={() => handleUpdateProgress(2)}
+              variant="secondary"
+              className="w-full sm:w-32 h-12 text-lg font-semibold"
+            >
               Hard
             </Button>
-            <Button onClick={() => handleUpdateProgress(3)} variant="secondary" className="w-full sm:w-32 h-12 text-lg font-semibold">
+            <Button
+              onClick={() => handleUpdateProgress(3)}
+              variant="secondary"
+              className="w-full sm:w-32 h-12 text-lg font-semibold"
+            >
               Good
             </Button>
-            <Button onClick={() => handleUpdateProgress(5)} className="bg-green-600 hover:bg-green-700 w-full sm:w-32 h-12 text-lg font-semibold">
+            <Button
+              onClick={() => handleUpdateProgress(5)}
+              className="bg-green-600 hover:bg-green-700 w-full sm:w-32 h-12 text-lg font-semibold"
+            >
               Easy
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- support "Again" (0) and "Hard" (2) review ratings in the Memorizer UI
- update review scheduling: quality 0 lapses cards, quality 2 halves current interval
- validate quality inputs and expand tests for new ratings

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688f0654b4148332a00c2a2fcf0dd11e