### PR TITLE
fix: stabilize initial location fetch effect

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -129,11 +129,17 @@ export default function Home() {
     [searchTerm, selectedCountries, pagination.limit, pagination.offset],
   );
 
+  // Keep the latest fetchLocations in a ref so effects can use a stable function
+  const fetchRef = useRef(fetchLocations);
+  useEffect(() => {
+    fetchRef.current = fetchLocations;
+  }, [fetchLocations]);
+
   // Initial fetch & refetch when filters change
   useEffect(() => {
-    fetchLocations(true);
+    fetchRef.current(true);
     // We intentionally omit pagination.offset from deps to avoid infinite loop
-  }, [searchTerm, selectedCountries, pagination.limit, fetchLocations]);
+  }, [searchTerm, selectedCountries, pagination.limit]);
 
   // Auto-refresh when the tab becomes visible or the window gains focus
   useEffect(() => {
@@ -153,12 +159,6 @@ export default function Home() {
   }, [fetchLocations]);
 
   // Infinite scroll observer to automatically fetch more locations
-  // Keep the latest fetchLocations in a ref so the observer callback is always fresh
-  const fetchRef = useRef(fetchLocations);
-  useEffect(() => {
-    fetchRef.current = fetchLocations;
-  }, [fetchLocations]);
-
   useEffect(() => {
     const sentinel = loadMoreRef.current;
     if (!sentinel || !pagination.hasMore) return;


### PR DESCRIPTION
## Summary
- hold `fetchLocations` in a ref so effects can call a stable function
- avoid unnecessary re-renders by removing `fetchLocations` from initial effect deps

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_688f07b249f483329a4283e2972f6e28