### PR TITLE
fix: sanitize MetaCard notes and add XSS test

### DIFF
--- a/app/src/__tests__/MetaCard.test.tsx
+++ b/app/src/__tests__/MetaCard.test.tsx
@@ -1,0 +1,38 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import MetaCard from "@/components/MetaCard";
+
+describe("MetaCard", () => {
+  it("sanitizes location.note to prevent XSS", async () => {
+    const malicious =
+      '<img src=x onerror="window.__xss=true"><script>window.__xss2=true</script><p>Safe</p>';
+    const location = {
+      id: 1,
+      country: "Testland",
+      country_code: null,
+      meta_name: null,
+      note: malicious,
+      footer: null,
+      images: [],
+      pano_id: "",
+      map_id: "",
+      created_at: "2020-01-01T00:00:00Z",
+      updated_at: "2020-01-01T00:00:00Z",
+    };
+
+    const { container } = render(
+      <MetaCard location={location} onDelete={() => {}} />,
+    );
+
+    fireEvent.click(container.firstChild as HTMLElement);
+
+    await waitFor(() => {
+      return document.querySelector(".prose div");
+    });
+
+    const noteHtml = document.querySelector(".prose div")!.innerHTML;
+
+    expect(noteHtml).not.toContain("onerror");
+    expect(noteHtml).not.toContain("<script");
+  });
+});

--- a/app/src/app/memorizer/page.test.tsx
+++ b/app/src/app/memorizer/page.test.tsx
@@ -2,9 +2,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import MemorizerPage from "./page";
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import * as matchers from "@testing-library/jest-dom/matchers";
-
-expect.extend(matchers);
+import "@testing-library/jest-dom/vitest";
 
 vi.mock("next/image", () => ({
   __esModule: true,

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -159,12 +159,7 @@ export default function Home() {
   }, [fetchLocations]);
 
   // Infinite scroll observer to automatically fetch more locations
-  // Keep the latest fetchLocations in a ref so the observer callback is always fresh
-  const fetchRef = useRef(fetchLocations);
-  useEffect(() => {
-    fetchRef.current = fetchLocations;
-  }, [fetchLocations]);
-
+  // Reuse the existing fetchRef so the observer callback is always fresh
   const loadingRef = useRef(loading);
   useEffect(() => {
     loadingRef.current = loading;

--- a/app/src/components/MetaCard.jsx
+++ b/app/src/components/MetaCard.jsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
+import DOMPurify from "dompurify";
 import {
   Dialog,
   DialogContent,
@@ -103,6 +104,10 @@ export default function MetaCard({ location, onDelete }) {
   };
 
   const footerLink = extractLink(location.footer);
+  // Sanitize user-provided HTML to avoid XSS issues
+  const sanitizedNote = location.note
+    ? DOMPurify.sanitize(location.note)
+    : "";
 
   // --- EFFECT FOR AUTO-SCROLL ---
   useEffect(() => {
@@ -286,7 +291,7 @@ export default function MetaCard({ location, onDelete }) {
           <div className="flex-1 overflow-y-scroll p-6 space-y-6 [scrollbar-gutter:stable]">
             {location.note && (
               <div className="prose prose-invert prose-slate max-w-none text-slate-200">
-                <div dangerouslySetInnerHTML={{ __html: location.note }} />
+                <div dangerouslySetInnerHTML={{ __html: sanitizedNote }} />
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- sanitize `location.note` in `MetaCard` with DOMPurify to prevent XSS
- add test ensuring malicious note HTML is scrubbed
- align test setup with jest-dom/vitest and reuse fetch ref for type-check stability

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test` *(fails: AssertionError in calculateNextReview and memorizer API tests)*
- `npm --prefix app test src/__tests__/MetaCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688f0cd7609083329ebedddbe118dde7