### PR TITLE
fix: move memorizer helper to utility module

### DIFF
--- a/app/src/__tests__/calculateNextReview.test.ts
+++ b/app/src/__tests__/calculateNextReview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { calculateNextReview } from '../app/api/memorizer/route';
+import { calculateNextReview } from '@/lib/memorizer';
 
 describe('calculateNextReview', () => {
   it('keeps new Hard answers in learning with a short delay', () => {

--- a/app/src/app/api/memorizer/route.ts
+++ b/app/src/app/api/memorizer/route.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { calculateNextReview } from "@/lib/memorizer";
 import { NextResponse } from "next/server";
 
 interface LocationRow {
@@ -27,95 +28,6 @@ interface Progress {
   interval: number;
   state: "new" | "learning" | "review" | "lapsed";
   lapses: number;
-}
-
-// Simple SM-2 algorithm implementation
-export function calculateNextReview(
-  quality: number,
-  repetitions: number,
-  easeFactor: number,
-  interval: number,
-  state: "new" | "learning" | "review" | "lapsed",
-  lapses: number,
-) {
-  let newState = state;
-  let newLapses = lapses;
-
-  // Brand new card answered "hard": keep it in learning and reshow
-  // it shortly instead of waiting a full day
-  if (repetitions === 0 && quality === 2 && state !== "lapsed") {
-    return {
-      repetitions: 0,
-      easeFactor,
-      interval: 0,
-      state: "learning",
-      lapses: newLapses,
-      reviewDelayMinutes: 5,
-    } as const;
-  }
-
-  if (quality === 0) {
-    // Lapsed card: dramatically reduce the interval but don't reset to a single day
-    newLapses += 1;
-    const newEaseFactor = Math.max(1.3, easeFactor - 0.2);
-    return {
-      repetitions: 0,
-      easeFactor: newEaseFactor,
-      interval: 7, // Revisit in about a week
-      state: "lapsed",
-      lapses: newLapses,
-    } as const;
-  }
-
-  if (state === "lapsed" && repetitions === 0 && quality >= 3) {
-    return {
-      repetitions: 0,
-      easeFactor,
-      interval: 0,
-      state: "learning",
-      lapses: newLapses,
-      reviewDelayMinutes: 10,
-    } as const;
-  }
-
-  let newRepetitions;
-  let newEaseFactor;
-  let newInterval;
-
-  if (repetitions === 0) {
-    newRepetitions = 1;
-    newInterval = 1;
-    newState = "learning";
-  } else if (repetitions === 1) {
-    newRepetitions = 2;
-    newInterval = quality === 2 ? 3 : 6;
-    newState = "review";
-  } else {
-    newRepetitions = repetitions + 1;
-    if (quality === 2) {
-      newInterval = Math.max(1, Math.round(interval / 2));
-    } else {
-      newInterval = Math.round(interval * easeFactor);
-      if (quality === 5) {
-        newInterval = Math.round(newInterval * 1.3);
-      }
-    }
-    newState = "review";
-  }
-
-  newEaseFactor =
-    easeFactor + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02));
-  if (newEaseFactor < 1.3) {
-    newEaseFactor = 1.3;
-  }
-
-  return {
-    repetitions: newRepetitions,
-    easeFactor: newEaseFactor,
-    interval: newInterval,
-    state: newState,
-    lapses: newLapses,
-  } as const;
 }
 
 // GET: Fetch the next card to review

--- a/app/src/lib/memorizer.ts
+++ b/app/src/lib/memorizer.ts
@@ -1,0 +1,88 @@
+export function calculateNextReview(
+  quality: number,
+  repetitions: number,
+  easeFactor: number,
+  interval: number,
+  state: "new" | "learning" | "review" | "lapsed",
+  lapses: number,
+) {
+  let newState = state;
+  let newLapses = lapses;
+
+  // Brand new card answered "hard": keep it in learning and reshow
+  // it shortly instead of waiting a full day
+  if (repetitions === 0 && quality === 2 && state !== "lapsed") {
+    return {
+      repetitions: 0,
+      easeFactor,
+      interval: 0,
+      state: "learning",
+      lapses: newLapses,
+      reviewDelayMinutes: 5,
+    } as const;
+  }
+
+  if (quality === 0) {
+    // Lapsed card: dramatically reduce the interval but don't reset to a single day
+    newLapses += 1;
+    const newEaseFactor = Math.max(1.3, easeFactor - 0.2);
+    return {
+      repetitions: 0,
+      easeFactor: newEaseFactor,
+      interval: 7, // Revisit in about a week
+      state: "lapsed",
+      lapses: newLapses,
+    } as const;
+  }
+
+  if (state === "lapsed" && repetitions === 0 && quality >= 3) {
+    return {
+      repetitions: 0,
+      easeFactor,
+      interval: 0,
+      state: "learning",
+      lapses: newLapses,
+      reviewDelayMinutes: 10,
+    } as const;
+  }
+
+  let newRepetitions;
+  let newEaseFactor;
+  let newInterval;
+
+  if (repetitions === 0) {
+    newRepetitions = 1;
+    newInterval = 1;
+    newState = "learning";
+  } else if (repetitions === 1) {
+    newRepetitions = 2;
+    newInterval = quality === 2 ? 3 : 6;
+    newState = "review";
+  } else {
+    newRepetitions = repetitions + 1;
+    if (quality === 2) {
+      newInterval = Math.max(1, Math.round(interval / 2));
+    } else {
+      newInterval = Math.round(interval * easeFactor);
+      if (quality === 5) {
+        newInterval = Math.round(newInterval * 1.3);
+      }
+    }
+    newState = "review";
+  }
+
+  newEaseFactor =
+    easeFactor + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02));
+  if (newEaseFactor < 1.3) {
+    newEaseFactor = 1.3;
+  }
+
+  return {
+    repetitions: newRepetitions,
+    easeFactor: newEaseFactor,
+    interval: newInterval,
+    state: newState,
+    lapses: newLapses,
+  } as const;
+}
+


### PR DESCRIPTION
## Summary
- move SM-2 `calculateNextReview` helper into `lib/memorizer`
- import helper in memorizer API route and tests

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test` *(fails: expected lapsed state and intervals differ)*
- `npm --prefix app run build`


------
https://chatgpt.com/codex/tasks/task_e_688f2362bfa08332857d06effc6d6287