### PR TITLE
feat: auto-refresh gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The backend provides a simple REST API:
 ### 🔍 Search & Filter
 - **Instant search** across all text content
 - **Country and continent dropdowns** with location counts
-- **Real-time results** with no page refreshes
+- **Live updates** every 3 seconds and when the tab becomes visible
 - **Search highlighting** in results
 
 ### 📱 Responsive Design

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -141,22 +141,28 @@ export default function Home() {
     // We intentionally omit pagination.offset from deps to avoid infinite loop
   }, [searchTerm, selectedCountries, selectedContinents, pagination.limit]);
 
-  // Auto-refresh when the tab becomes visible or the window gains focus
+  // Auto-refresh when the tab becomes visible
   useEffect(() => {
     const handleVisibility = () => {
       if (document.visibilityState === "visible") {
-        fetchLocations(true);
+        fetchRef.current(true);
       }
     };
 
     document.addEventListener("visibilitychange", handleVisibility);
-    window.addEventListener("focus", handleVisibility);
-
     return () => {
       document.removeEventListener("visibilitychange", handleVisibility);
-      window.removeEventListener("focus", handleVisibility);
     };
-  }, [fetchLocations]);
+  }, []);
+
+  // Auto-refresh every 3 seconds
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchRef.current(true);
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, []);
 
   // Infinite scroll observer to automatically fetch more locations
   // Reuse the existing fetchRef so the observer callback is always fresh


### PR DESCRIPTION
## Summary
- refresh gallery automatically every 3 seconds and when tab becomes visible
- document live gallery updates in README

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test` *(fails: Test timed out, assertion failures in calculateNextReview tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68946b291d0c833291fbaa49b576e7ea