### PR TITLE
fix: handle lapsed cards and timestamp parsing

### DIFF
--- a/app/src/lib/memorizer.ts
+++ b/app/src/lib/memorizer.ts
@@ -22,7 +22,7 @@ export function calculateNextReview(
     } as const;
   }
 
-  if (quality === 0) {
+  if (quality <= 1) {
     // Lapsed card: dramatically reduce the interval but don't reset to a single day
     newLapses += 1;
     const newEaseFactor = Math.max(1.3, easeFactor - 0.2);
@@ -37,9 +37,9 @@ export function calculateNextReview(
 
   if (state === "lapsed" && repetitions === 0 && quality >= 3) {
     return {
-      repetitions: 0,
+      repetitions: 1,
       easeFactor,
-      interval: 0,
+      interval: 1,
       state: "learning",
       lapses: newLapses,
       reviewDelayMinutes: 10,


### PR DESCRIPTION
## Summary
- treat quality 0–1 responses as lapses and reset intervals
- let lapsed cards re-enter learning with a 10‑minute follow-up
- support more review quality values and parse Unix timestamps in seconds

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_68946ea4a7808332be4860f02e4c9418