### PR TITLE
feat: add keyboard shortcuts to memorizer

### DIFF
--- a/app/src/app/memorizer/page.test.tsx
+++ b/app/src/app/memorizer/page.test.tsx
@@ -76,3 +76,69 @@ describe("MemorizerPage update errors", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("MemorizerPage keyboard shortcuts", () => {
+  it("updates progress when shortcut keys are pressed", async () => {
+    const location = {
+      id: 1,
+      pano_id: "p1",
+      map_id: "m1",
+      country: "USA",
+      country_code: "US",
+      meta_name: null,
+      note: null,
+      footer: null,
+      images: [],
+      raw_data: {},
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const successResponse = {
+      success: true,
+      location,
+      stats: {
+        new: 0,
+        review: 0,
+        lapsed: 0,
+        newTotal: 0,
+        reviewTotal: 0,
+        lapsedTotal: 0,
+      },
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(successResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify(successResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+    (global as any).fetch = fetchMock;
+
+    render(<MemorizerPage />);
+
+    await waitFor(() => expect(screen.getByText("Good")).toBeInTheDocument());
+
+    fireEvent.keyDown(window, { key: "1" });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    const postCall = fetchMock.mock.calls[1];
+    expect(postCall[1]?.body).toContain('"quality":0');
+  });
+});

--- a/app/src/app/memorizer/page.tsx
+++ b/app/src/app/memorizer/page.tsx
@@ -53,27 +53,55 @@ export default function MemorizerPage() {
     fetchNextCard();
   }, [fetchNextCard]);
 
-  const handleUpdateProgress = async (quality: number) => {
-    if (!location) return;
-    setUpdateError(null);
-    try {
-      const res = await fetch("/api/memorizer", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ locationId: location.id, quality }),
-      });
-      const data = await res.json();
-      if (!res.ok || !data.success) {
-        throw new Error(data.message || "Failed to update progress.");
+  const handleUpdateProgress = useCallback(
+    async (quality: number) => {
+      if (!location) return;
+      setUpdateError(null);
+      try {
+        const res = await fetch("/api/memorizer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ locationId: location.id, quality }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data.success) {
+          throw new Error(data.message || "Failed to update progress.");
+        }
+        fetchNextCard();
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "An unknown error occurred";
+        setUpdateError(message);
+        console.error("Failed to update progress:", error);
       }
-      fetchNextCard();
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "An unknown error occurred";
-      setUpdateError(message);
-      console.error("Failed to update progress:", error);
-    }
-  };
+    },
+    [fetchNextCard, location]
+  );
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "1":
+        case "ArrowLeft":
+          handleUpdateProgress(0);
+          break;
+        case "2":
+        case "ArrowDown":
+          handleUpdateProgress(2);
+          break;
+        case "3":
+        case "ArrowUp":
+          handleUpdateProgress(3);
+          break;
+        case "4":
+        case "ArrowRight":
+          handleUpdateProgress(5);
+          break;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [handleUpdateProgress]);
 
   const renderContent = () => {
     if (loading) {
@@ -152,6 +180,9 @@ export default function MemorizerPage() {
               Easy
             </Button>
           </div>
+          <p className="mt-2 text-center text-xs text-slate-400">
+            Shortcuts: 1–4 or arrow keys
+          </p>
           {updateError && (
             <p className="mt-4 text-red-400">{updateError}</p>
           )}


### PR DESCRIPTION
## Summary
- map number and arrow keys to review buttons
- hint users about available shortcuts
- test keyboard shortcut handling

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`

------
https://chatgpt.com/codex/tasks/task_e_689474491dd48332b3981659eac9a14f