### PR TITLE
feat: add review stats dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ NEW v2.0: Userscript → Backend API → LearnableMeta API → JSON Storage → 
 - "Good" answers progress intervals like 1 → 6 → 15 days
 - "Easy" answers add a 30% bonus after the second review for 1 → 6 → 20 days
 - Header shows due-today and total counts for new, review, and lapsed cards
+- Dashboard with daily review counts and success rates
 
 ## 🚀 Quick Start
 
@@ -309,7 +310,7 @@ MIT License - Use this however you'd like for personal/educational purposes.
 Future improvements might include:
 - Spaced repetition system for studying
 - Export to Anki flashcards
-- Statistics and learning progress
+- Enhanced statistics and learning progress
 - Collaborative features for sharing collections
 - Integration with other geography learning tools
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "better-sqlite3": "^12.2.0",
+        "chart.js": "^4.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -23,6 +24,7 @@
         "lucide-react": "^0.535.0",
         "next": "^15.4.5",
         "react": "^19.1.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.1",
         "react-window": "^1.8.11",
         "tailwind-merge": "^3.3.1",
@@ -1421,6 +1423,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -4076,6 +4084,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -7752,6 +7772,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/app/package.json
+++ b/app/package.json
@@ -29,22 +29,26 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "better-sqlite3": "^12.2.0",
+    "chart.js": "^4.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "countries-list": "^3.1.1",
     "dompurify": "^3.2.6",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.535.0",
     "next": "^15.4.5",
     "react": "^19.1.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.1",
     "react-window": "^1.8.11",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.17",
-    "tailwindcss-animate": "^1.0.7",
-    "countries-list": "^3.1.1"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.4",
+    "@testing-library/react": "^16.3.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.1.0",
     "@types/react": "^19.1.9",
@@ -52,12 +56,10 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9.32.0",
     "eslint-config-next": "^15.4.5",
+    "jsdom": "^24.0.0",
     "postcss": "^8.5.6",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/jest-dom": "^6.6.4",
-    "jsdom": "^24.0.0"
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/app/src/app/api/stats/route.ts
+++ b/app/src/app/api/stats/route.ts
@@ -1,0 +1,47 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+interface StatRow {
+  day: string;
+  total: number;
+  success: number;
+}
+
+export async function GET() {
+  try {
+    const rows = db
+      .prepare(
+        `
+        SELECT
+          date(datetime(reviewed_at, 'unixepoch')) AS day,
+          COUNT(*) AS total,
+          SUM(CASE WHEN quality >= 3 THEN 1 ELSE 0 END) AS success
+        FROM memorizer_reviews
+        GROUP BY day
+        ORDER BY day ASC
+      `,
+      )
+      .all() as StatRow[];
+
+    const data = rows.map(({ day, total, success }) => ({
+      day,
+      count: total,
+      successRate: total > 0 ? success / total : 0,
+    }));
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /no such table/i.test(error.message)
+    ) {
+      return NextResponse.json({ success: true, data: [] });
+    }
+    console.error("Error fetching stats:", error);
+    return NextResponse.json(
+      { success: false, message: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/app/src/app/memorizer/page.tsx
+++ b/app/src/app/memorizer/page.tsx
@@ -3,7 +3,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
-import { BrainCircuit, Loader2, AlertTriangle, ChevronLeft } from "lucide-react";
+import {
+  BrainCircuit,
+  Loader2,
+  AlertTriangle,
+  ChevronLeft,
+  BarChart3,
+} from "lucide-react";
 import Link from "next/link";
 import MemorizerCard, { Location } from "@/components/MemorizerCard.tsx"; // Use the new component
 
@@ -208,12 +214,21 @@ export default function MemorizerPage() {
               <BrainCircuit className="h-7 w-7 mr-2" />
               <span className="hidden sm:inline">Meta Memorizer</span>
             </h1>
-            <div className="w-10 sm:w-36 text-right">
+            <div className="w-10 sm:w-36 flex items-center justify-end gap-2 text-right">
               {stats && !loading && (
                 <span className="text-xs sm:text-sm text-slate-500">
                   {stats.new}/{stats.newTotal} new, {stats.review}/{stats.reviewTotal} reviews, {stats.lapsed}/{stats.lapsedTotal} lapsed due today
                 </span>
               )}
+              <Link href="/stats" aria-label="Review stats">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="bg-slate-700 border-slate-600 text-white hover:bg-slate-600 h-10 w-10"
+                >
+                  <BarChart3 className="h-5 w-5" />
+                </Button>
+              </Link>
             </div>
           </div>
         </div>

--- a/app/src/app/stats/page.tsx
+++ b/app/src/app/stats/page.tsx
@@ -1,0 +1,11 @@
+import ProgressDashboard from "@/components/ProgressDashboard";
+
+export default function StatsPage() {
+  return (
+    <div className="min-h-screen bg-slate-900 text-white p-4">
+      <h1 className="text-2xl font-bold mb-4">Review Stats</h1>
+      <ProgressDashboard />
+    </div>
+  );
+}
+

--- a/app/src/components/ProgressDashboard.tsx
+++ b/app/src/components/ProgressDashboard.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+);
+
+interface DailyStat {
+  day: string;
+  count: number;
+  successRate: number;
+}
+
+export default function ProgressDashboard() {
+  const [stats, setStats] = useState<DailyStat[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/stats")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success) {
+          setStats(data.data);
+        } else {
+          setError(data.message || "Failed to load stats");
+        }
+      })
+      .catch((err) => setError(err.message));
+  }, []);
+
+  if (error) {
+    return <p className="text-red-500">{error}</p>;
+  }
+
+  const labels = stats.map((s) => s.day);
+  const counts = stats.map((s) => s.count);
+  const rates = stats.map((s) => Math.round(s.successRate * 100));
+
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: "Reviews",
+        data: counts,
+        borderColor: "rgb(59,130,246)",
+        backgroundColor: "rgba(59,130,246,0.2)",
+        yAxisID: "y",
+      },
+      {
+        label: "Success %",
+        data: rates,
+        borderColor: "rgb(34,197,94)",
+        backgroundColor: "rgba(34,197,94,0.2)",
+        yAxisID: "y1",
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    interaction: { mode: "index" as const, intersect: false },
+    scales: {
+      y: { beginAtZero: true, position: "left" as const },
+      y1: {
+        beginAtZero: true,
+        position: "right" as const,
+        grid: { drawOnChartArea: false },
+        ticks: {
+          callback: (val: number | string) => `${val}%`,
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      <Line options={options} data={data} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/api/stats` endpoint for daily review counts and success rates
- chart-based `ProgressDashboard` with Chart.js
- link stats dashboard from memorizer page

## Testing
- `npm --prefix app run lint`
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_68948e733738833292f005288f733843